### PR TITLE
Windows needs retention time set

### DIFF
--- a/jenkins-config/clouds/openstack/cattle/ws2016-win-builder-4c-4g.cfg
+++ b/jenkins-config/clouds/openstack/cattle/ws2016-win-builder-4c-4g.cfg
@@ -1,4 +1,5 @@
 IMAGE_NAME=ZZCI - Windows 2016 - win-builder - x86_64 - 20180711-004849.649
 HARDWARE_ID=v1-standard-4
 USER_DATA_ID=jenkins-init-script-windows
+RETENTION_TIME=5
 CONNECTION_TYPE=JNLP


### PR DESCRIPTION
Windows takes a long time to boot and requries retention time
configured otherwise the VM won't have enough time to connect.

Signed-off-by: Thanh Ha <thanh.ha@linuxfoundation.org>